### PR TITLE
firestore上で書籍名ではなく、isbnによって書籍を区別

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -110,7 +110,7 @@ export default Vue.extend({
         .collection("reviews")
         .doc(this.lang)
         .collection(String(this.skills.indexOf(this.skill)))
-        .doc(this.book.title);
+        .doc(this.book.isbn);
       titleDoc.set({
         title: this.book.title,
         imageURL: this.book.imageURL,

--- a/src/components/PostCard.vue
+++ b/src/components/PostCard.vue
@@ -50,9 +50,7 @@
 
     <v-card-actions>
       <router-link
-        :to="`/${this.lang}/${this.skills.indexOf(this.skill)}/${encode(
-          this.review.title
-        )}`"
+        :to="`/${this.lang}/${this.skills.indexOf(this.skill)}/${this.review.isbn}`"
         >詳細</router-link
       >
     </v-card-actions>

--- a/src/views/Detail.vue
+++ b/src/views/Detail.vue
@@ -106,7 +106,7 @@ export default Vue.extend({
       .collection("reviews")
       .doc(this.$route.params.lang)
       .collection(this.$route.params.skill)
-      .doc(this.decode());
+      .doc(this.$route.params.id);
 
     bookDoc.get().then((doc) => {
       this.book = doc.data() as object;

--- a/src/views/RakutenBookSearch.vue
+++ b/src/views/RakutenBookSearch.vue
@@ -58,7 +58,7 @@ export default Vue.extend({
   }),
   methods: {
     searchBook() {
-      this.searchResults = []
+      this.searchResults = [];
       axios
         .get(
           `https://app.rakuten.co.jp/services/api/BooksTotal/Search/20170404?format=json&keyword=${this.search}&applicationId=${process.env.VUE_APP_RAKUTEN_APP}`
@@ -73,12 +73,14 @@ export default Vue.extend({
                 isbn?: string;
               };
             }) => {
-              this.searchResults.push({
-                title: book.Item.title,
-                caption: book.Item.itemCaption,
-                imageURL: book.Item.largeImageUrl,
-                isbn: book.Item.isbn,
-              });
+              if (book.Item.isbn) {
+                this.searchResults.push({
+                  title: book.Item.title,
+                  caption: book.Item.itemCaption,
+                  imageURL: book.Item.largeImageUrl,
+                  isbn: book.Item.isbn,
+                });
+              }
             }
           );
         });


### PR DESCRIPTION
Slackに共有した時は書籍のタイトルをidの用に扱いfirestore上で書籍を区別していたのですが、書籍ごとの詳細ページにアクセスする際、URLに書籍のタイトルを含める必要があり日本語をURLに含めるのはあまり良くないと思い、エンコードしてURLに含めていました。
しかし、isbnを用いることで書籍ごとに予め振られているユニークなidなのでfirestore、詳細ページにアクセスする際のURL共に管理が簡単になり、文字列をエンコードする必要が無いので仕様を変更しました。

そもそもisbnを使用する案はあったのですが、楽天BooksAPIを叩いてみると雑誌など一部isbnが振られていない本があったので、nullをfirestoreに書籍のidとして保存するわけには行かないと思っていたのですが、プログラミングの書籍に関しては基本isbnが振られていることが分かったのでisbnで管理する仕様に変更しました。